### PR TITLE
Add portzap-install-port

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ is maintained as a git repository, and portzap allows the repository to be clone
   This command should be run by a user account that is a member of the `_portzap` group. <br>
   The command updates an existing repository previously cloned with `portzap clone`.
 
-* **portzap unpack** <br>
+* **portzap install** <br>
   This command should be run as root. <br>
-  The command copies `/home/_portzap/ports` to `/usr/ports`.
+  The command installs `/home/_portzap/ports` into `/usr/ports`.
 
 ## Sources
 

--- a/bin/portzap
+++ b/bin/portzap
@@ -4,16 +4,19 @@
 
 ##
 # Configuration
-source="https://git.hardenedbsd.org/hardenedbsd/ports.git"
+source_url="https://git.hardenedbsd.org/hardenedbsd/ports.git"
 transient_dir="/home/_portzap/ports"
-final_dir="/usr/ports/"
+rest_dir="/usr/ports/"
+
+##
+# Default masks
+init_mask=707
+clone_mask=007
+pull_mask=007
 
 ##
 # Default modes
-init_mode=707
-clone_mode=007
-pull_mode=007
-unpack_mode=022
+unpack_mode="u=rwX,g=rX,o=rX"
 
 ##
 # Utils
@@ -58,7 +61,7 @@ init() {
         echo "The init command should be run as root."
         exit 1
     fi;
-    umask $init_mode
+    umask $init_mask
     pw userdel _portzap -r
     pw useradd _portzap -m -s /sbin/nologin
 }
@@ -72,8 +75,8 @@ clone() {
             echo "Run 'portzap pull' instead."
             exit 1
         fi
-        umask $clone_mode
-        git clone --depth 1 $source $transient_dir
+        umask $clone_mask
+        git clone --depth 1 $source_url $transient_dir
     else
         echo "Permission denied."
     fi
@@ -84,7 +87,7 @@ pull() {
     then
         if [ -e "$transient_dir/.git" ];
         then
-            umask $pull_mode
+            umask $pull_mask
             cd $transient_dir
             git pull --rebase origin hardenedbsd/main
         else
@@ -103,8 +106,10 @@ unpack() {
         echo "The unpack command should be run as root."
         exit 1
     fi
-    umask $unpack_mode
-    cp -Rfv "$transient_dir/." $final_dir
+    cd $transient_dir
+    find . -maxdepth 1 -type f -exec install -m=$unpack_mode {} $rest_dir \;
+    find . -maxdepth 1 -type d -exec mkdir -p -m $unpack_mode $rest_dir/{} \;
+    find . -depth 2 -type d -exec portzap-install-port {} $rest_dir $unpack_mode \;
 }
 
 case $1 in

--- a/bin/portzap
+++ b/bin/portzap
@@ -16,7 +16,7 @@ pull_mask=007
 
 ##
 # Default modes
-unpack_mode="u=rwX,g=rX,o=rX"
+install_mode="u=rwX,g=rX,o=rX"
 
 ##
 # Utils
@@ -52,7 +52,7 @@ user_is_not_root() {
 ##
 # Commands
 help() {
-    echo "Usage: portzap init|clone|pull|unpack"
+    echo "Usage: portzap init|clone|pull|install"
 }
 
 init() {
@@ -100,16 +100,16 @@ pull() {
     fi
 }
 
-unpack() {
+install() {
     if user_is_not_root;
     then
-        echo "The unpack command should be run as root."
+        echo "The install command should be run as root."
         exit 1
     fi
     cd $transient_dir
-    find . -maxdepth 1 -type f -exec install -m=$unpack_mode {} $rest_dir \;
-    find . -maxdepth 1 -type d -exec mkdir -p -m $unpack_mode $rest_dir/{} \;
-    find . -depth 2 -type d -exec portzap-install-port {} $rest_dir $unpack_mode \;
+    find . -maxdepth 1 -type f -exec install -m=$install_mode {} $rest_dir \;
+    find . -maxdepth 1 -type d -exec mkdir -p -m $install_mode $rest_dir/{} \;
+    find . -depth 2 -type d -exec portzap-install-port {} $rest_dir $install_mode \;
 }
 
 case $1 in
@@ -127,8 +127,8 @@ case $1 in
         pull
         break
         ;;
-    "unpack")
-        unpack
+    "install")
+        install
         break
         ;;
     *)

--- a/bin/portzap-install-port
+++ b/bin/portzap-install-port
@@ -1,0 +1,15 @@
+#!/bin/sh
+src=$1
+dest=$2/${src}
+mode=$3
+group=_portzap
+install_args="-m $mode"
+
+mkdir -m $mode -p $dest
+find $src -maxdepth 1 -type f -execdir install $install_args {} $dest/{} \;
+if [ -d "$src/files" ];
+then
+    mkdir -m $mode -p $dest/files
+    find $src/files -maxdepth 1 -type f -execdir install $install_args {} $dest/files \;
+fi
+echo Install $(realpath $dest)


### PR DESCRIPTION
Add a new script that is responsible for installing a new port
to /usr/ports with the correct permissions.

~~This change will unpack `/home/_portzap/ports` to `/usr/ports`,
and honor `unpack_mode` in the process. The performance is not
good, and it is something to improve.~~